### PR TITLE
Simplify Google Meet interface for focus

### DIFF
--- a/meeetpro/README.md
+++ b/meeetpro/README.md
@@ -1,0 +1,24 @@
+# MeeetPRO (Chrome Extension)
+
+MeeetPRO toggles a distraction-free spotlight view in Google Meet:
+- Hides Meet UI chrome while keeping the pinned (spotlight) video visible
+- Keeps the People panel accessible so you can pin/unpin participants
+- Forces square corners and sizes the main video to 1280x720
+
+## Install (Unpacked)
+1. Build not required. Open Chrome and go to `chrome://extensions`.
+2. Toggle "Developer mode" (top-right).
+3. Click "Load unpacked" and select this folder (`meeetpro`).
+
+## Usage
+- Open a Google Meet at `https://meet.google.com/*`.
+- Click the MeeetPRO toolbar icon to toggle on/off.
+- Or use the shortcut Alt+Shift+M to toggle.
+
+## Notes
+- The content script keeps the largest visible `<video>` as the spotlight target and tries to keep the People panel visible. If the panel is closed, MeeetPRO attempts to open it.
+- DOM in Meet changes frequently; the extension uses robust fallbacks and a MutationObserver to re-apply layout.
+- While enabled, the stage centers the video on a black backdrop. The People panel remains on the right when present.
+
+## Privacy
+- No network access. No data leaves your browser.

--- a/meeetpro/background.js
+++ b/meeetpro/background.js
@@ -1,0 +1,21 @@
+// MeeetPRO background service worker (MV3)
+
+chrome.action.onClicked.addListener(async (tab) => {
+  if (!tab || !tab.id) return;
+  try {
+    await chrome.tabs.sendMessage(tab.id, { type: 'MEEETPRO_TOGGLE' });
+  } catch (err) {
+    // Tab may not have content script (wrong site), ignore
+  }
+});
+
+chrome.commands.onCommand.addListener(async (command) => {
+  if (command !== 'toggle-meetpro') return;
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab || !tab.id) return;
+  try {
+    await chrome.tabs.sendMessage(tab.id, { type: 'MEEETPRO_TOGGLE' });
+  } catch (err) {
+    // Ignore if not on Meet or content script not injected yet
+  }
+});

--- a/meeetpro/content.js
+++ b/meeetpro/content.js
@@ -1,0 +1,258 @@
+(() => {
+  const STATE = {
+    enabled: false,
+    enforceIntervalId: null,
+    mutationObserver: null,
+    currentStageEl: null,
+    currentVideoEl: null,
+    currentPeopleEl: null,
+  };
+
+  const STYLE_ID = 'meeetpro-style';
+  const ROOT_ON_CLASS = 'meeetpro-on';
+  const KEEP_CLASS = 'meeetpro-keep';
+  const STAGE_CLASS = 'meeetpro-stage';
+  const PEOPLE_CLASS = 'meeetpro-people';
+
+  function injectStyleOnce() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+      html.${ROOT_ON_CLASS} body :not(.${KEEP_CLASS}):not(.${KEEP_CLASS} *) { display: none !important; }
+      html.${ROOT_ON_CLASS} video, html.${ROOT_ON_CLASS} canvas, html.${ROOT_ON_CLASS} img { border-radius: 0 !important; }
+      html.${ROOT_ON_CLASS} .${STAGE_CLASS} { position: fixed !important; top: 0 !important; left: 0 !important; bottom: 0 !important; right: 0 !important; display: flex !important; align-items: center !important; justify-content: center !important; background: #000 !important; z-index: 1 !important; }
+      html.${ROOT_ON_CLASS} .${PEOPLE_CLASS} { position: fixed !important; top: 0 !important; right: 0 !important; bottom: 0 !important; z-index: 2 !important; }
+    `;
+    document.documentElement.appendChild(style);
+  }
+
+  function removeStyleIfAny() {
+    const style = document.getElementById(STYLE_ID);
+    if (style) style.remove();
+  }
+
+  function isElementVisible(el) {
+    if (!el || !(el instanceof Element)) return false;
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return false;
+    const style = window.getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return false;
+    return true;
+  }
+
+  function findLargestVideo() {
+    const videos = Array.from(document.querySelectorAll('video'));
+    let best = null;
+    let bestArea = 0;
+    for (const v of videos) {
+      if (!isElementVisible(v)) continue;
+      const r = v.getBoundingClientRect();
+      const area = r.width * r.height;
+      if (area > bestArea) {
+        best = v;
+        bestArea = area;
+      }
+    }
+    return best;
+  }
+
+  function markKeepForChain(el) {
+    let node = el;
+    while (node && node !== document.body) {
+      node.classList.add(KEEP_CLASS);
+      node = node.parentElement;
+    }
+  }
+
+  function clearKeepMarks() {
+    for (const el of Array.from(document.querySelectorAll('.' + KEEP_CLASS))) {
+      el.classList.remove(KEEP_CLASS);
+      el.classList.remove(STAGE_CLASS);
+      el.classList.remove(PEOPLE_CLASS);
+      // Clean inline styles we might have set
+      if (el === STATE.currentVideoEl) {
+        el.style.width = '';
+        el.style.height = '';
+        el.style.maxWidth = '';
+        el.style.maxHeight = '';
+        el.style.objectFit = '';
+      }
+      if (el === STATE.currentPeopleEl || el === STATE.currentStageEl) {
+        el.style.right = '';
+        el.style.width = '';
+        el.style.zIndex = '';
+      }
+    }
+  }
+
+  function sizeVideo1280x720(videoEl) {
+    if (!videoEl) return;
+    videoEl.style.width = '1280px';
+    videoEl.style.height = '720px';
+    videoEl.style.maxWidth = 'none';
+    videoEl.style.maxHeight = 'none';
+    videoEl.style.objectFit = 'contain';
+  }
+
+  function findPeoplePanel() {
+    // Try several selectors that commonly match the People panel
+    const candidates = [
+      '[data-panel-id="people"]',
+      '[aria-label="People"]',
+      '[aria-label*="People"]',
+      'div[role="region"][aria-label*="People"]',
+      'div[role="tabpanel"][aria-label*="People"]'
+    ];
+    for (const sel of candidates) {
+      const el = document.querySelector(sel);
+      if (el && isElementVisible(el)) return el;
+    }
+    return null;
+  }
+
+  function ensurePeoplePanelOpen() {
+    // If not visible, try to click a People/Show everyone button
+    let panel = findPeoplePanel();
+    if (panel) return panel;
+
+    const btnSelectors = [
+      'button[aria-label*="People"]',
+      'button[aria-label*="Show everyone"]',
+      '[data-tooltip*="People"]',
+      '[data-tooltip*="Everyone"]'
+    ];
+    for (const sel of btnSelectors) {
+      const btn = document.querySelector(sel);
+      if (btn) {
+        btn.click();
+        break;
+      }
+    }
+    // Give the DOM a moment to render
+    return findPeoplePanel();
+  }
+
+  function layoutStageAroundPeople(stageEl, peopleEl) {
+    if (!stageEl) return;
+    // Default: full viewport
+    stageEl.classList.add(STAGE_CLASS);
+    if (!peopleEl || !isElementVisible(peopleEl)) return;
+
+    // Estimate panel width and leave space for it by setting stageEl right inset
+    const rect = peopleEl.getBoundingClientRect();
+    const panelWidth = Math.max(0, Math.floor(rect.width));
+    stageEl.style.right = panelWidth ? `${panelWidth}px` : '0';
+    // Ensure panel stays above stage
+    peopleEl.classList.add(PEOPLE_CLASS);
+    peopleEl.style.zIndex = '2';
+  }
+
+  function enforceOnce() {
+    clearKeepMarks();
+
+    const largestVideo = findLargestVideo();
+    STATE.currentVideoEl = largestVideo;
+    if (largestVideo) {
+      markKeepForChain(largestVideo);
+      sizeVideo1280x720(largestVideo);
+
+      // The top-most kept ancestor (closest to body) will become the stage
+      let stageEl = largestVideo;
+      let prev = null;
+      while (stageEl && stageEl.parentElement && stageEl.parentElement !== document.body) {
+        prev = stageEl;
+        stageEl = stageEl.parentElement;
+      }
+      // If prev exists, use the ancestor just under body as stage, else use current container
+      STATE.currentStageEl = stageEl || largestVideo;
+      STATE.currentStageEl.classList.add(KEEP_CLASS);
+      STATE.currentStageEl.classList.add(STAGE_CLASS);
+    }
+
+    // Keep the People panel as well
+    const peopleEl = ensurePeoplePanelOpen();
+    if (peopleEl) {
+      STATE.currentPeopleEl = peopleEl;
+      markKeepForChain(peopleEl);
+      peopleEl.classList.add(PEOPLE_CLASS);
+    }
+
+    // Layout adjustments after both are identified
+    layoutStageAroundPeople(STATE.currentStageEl, STATE.currentPeopleEl);
+  }
+
+  function startEnforcement() {
+    if (STATE.enforceIntervalId) return;
+    STATE.enforceIntervalId = setInterval(enforceOnce, 800);
+
+    if (!STATE.mutationObserver) {
+      STATE.mutationObserver = new MutationObserver(() => {
+        // Debounce by scheduling the next tick
+        if (STATE.enabled) {
+          queueMicrotask(enforceOnce);
+        }
+      });
+      STATE.mutationObserver.observe(document.body || document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+      });
+    }
+  }
+
+  function stopEnforcement() {
+    if (STATE.enforceIntervalId) {
+      clearInterval(STATE.enforceIntervalId);
+      STATE.enforceIntervalId = null;
+    }
+    if (STATE.mutationObserver) {
+      STATE.mutationObserver.disconnect();
+      STATE.mutationObserver = null;
+    }
+  }
+
+  function enable() {
+    if (STATE.enabled) return;
+    STATE.enabled = true;
+    injectStyleOnce();
+    document.documentElement.classList.add(ROOT_ON_CLASS);
+    enforceOnce();
+    startEnforcement();
+  }
+
+  function disable() {
+    if (!STATE.enabled) return;
+    STATE.enabled = false;
+    stopEnforcement();
+    document.documentElement.classList.remove(ROOT_ON_CLASS);
+    clearKeepMarks();
+    removeStyleIfAny();
+  }
+
+  function toggle() {
+    if (STATE.enabled) disable(); else enable();
+  }
+
+  // Toggle message from background
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (!msg || msg.type !== 'MEEETPRO_TOGGLE') return;
+    try {
+      toggle();
+      sendResponse && sendResponse({ ok: true, enabled: STATE.enabled });
+    } catch (e) {
+      sendResponse && sendResponse({ ok: false, error: String(e) });
+    }
+    // Keep channel open only if we plan async response; we don't
+    return false;
+  });
+
+  // Optional: expose a keyboard fallback inside page (Alt+Shift+M) if background commands fail
+  window.addEventListener('keydown', (e) => {
+    if (e.altKey && e.shiftKey && (e.key === 'M' || e.key === 'm')) {
+      toggle();
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }, true);
+})();

--- a/meeetpro/manifest.json
+++ b/meeetpro/manifest.json
@@ -1,0 +1,34 @@
+{
+  "manifest_version": 3,
+  "name": "MeeetPRO",
+  "description": "Toggle a distraction-free spotlight view in Google Meet while keeping the People panel accessible. Forces square 1280x720 video.",
+  "version": "0.1.0",
+  "action": {
+    "default_title": "MeeetPRO: Toggle Clean Spotlight"
+  },
+  "permissions": [
+    "tabs",
+    "storage"
+  ],
+  "host_permissions": [
+    "https://meet.google.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://meet.google.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "commands": {
+    "toggle-meetpro": {
+      "suggested_key": {
+        "default": "Alt+Shift+M"
+      },
+      "description": "Toggle MeeetPRO on the current Meet tab"
+    }
+  }
+}


### PR DESCRIPTION
Adds MeeetPRO Chrome extension to provide a togglable, distraction-free Google Meet view, keeping only the spotlight video (1280x720, square corners) and the people panel.

---
<a href="https://cursor.com/background-agent?bcId=bc-5250b34b-bb10-40b4-8e18-38336d756116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5250b34b-bb10-40b4-8e18-38336d756116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

